### PR TITLE
fix: manually remove collapsed property.

### DIFF
--- a/public/comps/Block.jsx
+++ b/public/comps/Block.jsx
@@ -40,7 +40,7 @@ export default function Block({ root, block, levels, headingType }) {
     <>
       <div class="kef-tocgen-block">
         {(block.level === 1 ||
-          (block.level < levels && block.children.length > 0)) && (
+          (block.level < levels && (headingType === HeadingTypes.h ? block.children.filter(b => b.content.startsWith("#")).length > 0 : block.children.length > 0))) && (
           <button class="kef-tocgen-arrow" onClick={toggleCollapsed}>
             <Arrow style={{ transform: collapsed ? null : "rotate(90deg)" }} />
           </button>

--- a/public/utils.js
+++ b/public/utils.js
@@ -19,6 +19,8 @@ export async function parseContent(content) {
     )}`
   }
 
+  // Remove collapsed property.
+  content = content.replace(/collapsed:: [^\n]+/g, "")
   // Remove properties.
   content = content.replace(/\b[^:\n]+:: [^\n]+/g, "")
 

--- a/public/utils.js
+++ b/public/utils.js
@@ -27,7 +27,23 @@ export async function parseContent(content) {
   // Remove page refs
   content = content.replace(/\[\[([^\]]+)\]\]/g, "$1")
 
+  // Remove html escape characters. For exmaple: "&amp;"
+  content = htmlDecode(content)
+
   return content.trim()
+}
+
+function htmlDecode(str) {
+  if (str.length === 0) {
+    return "";
+  }
+
+  return str.replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&#39;/g, "\'")
+    .replace(/&quot;/g, "\"");
 }
 
 export const HeadingTypes = {


### PR DESCRIPTION
When a block is collapsed, the TOC will be incomplete. Here is the explanation:

>It could be a bug of Logseq. Other properties I observed all begin with a white space.

When a block is collapsed, the "collapsed" properly doesn't begin with a white space, for example, a collapsed block with content "somewords" could be: "somewordscollapsed:: true". In this case, "somewordscollapsed:: true" will entirely be replaced with empty string.