### PR TITLE
fix: embed blocks donot gen toc

### DIFF
--- a/src/comps/TocGen.jsx
+++ b/src/comps/TocGen.jsx
@@ -298,7 +298,7 @@ function isValid(block, content, headingType) {
   return (
     block.properties?.toc !== "no" &&
     content &&
-    !/^\s*{{/.test(content) &&
+    !/^\s*{{(?!embed )/.test(content) &&
     (headingType !== HeadingTypes.h || isHeading(block))
   )
 }


### PR DESCRIPTION
The macros check code `!/^\s*{{/.test(content))` in method `isValid` happends before processing embed blocks. So all embed blocks were skipped to gen TOC.

I modified `isValid` method to check macros unless the block is not embeded.